### PR TITLE
Wrap Alias call for Mixpanel

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ RNSegmentIO.identify(userId: string, traits: Object)
 RNSegmentIO.track(trackText: string, properties: Object)
 
 RNSegmentIO.screen(screenName: string, properties: Object)
+
+RNSegmentIO.alias(newId: string)
 ```
 
 > **Note:** remember to import it in every file you are going to use it.

--- a/android/src/main/java/com/charlires/segmentanalytics/SegmentAnalyticsModule.java
+++ b/android/src/main/java/com/charlires/segmentanalytics/SegmentAnalyticsModule.java
@@ -66,6 +66,15 @@ public class SegmentAnalyticsModule extends ReactContextBaseJavaModule {
                 this.toProperties(properties));
     }
 
+    @ReactMethod
+    public void alias(String newId) {
+        Analytics.with(this.getReactApplicationContext()).alias(
+                newId,
+                null
+        );
+
+    }
+
     public Properties toProperties(@Nullable ReadableMap readableMap) {
         if (readableMap == null) {
             return null;

--- a/index.js
+++ b/index.js
@@ -19,5 +19,9 @@ export default {
 
   screen: function (screenName: string, properties: Object) {
     SegmentAnalytics.screen(screenName, properties);
+  },
+
+  alias: function (newId: string) {
+    SegmentAnalytics.alias(newId);
   }
 };

--- a/ios/SegmentAnalytics/Classes/SegmentAnalytics.m
+++ b/ios/SegmentAnalytics/Classes/SegmentAnalytics.m
@@ -31,6 +31,10 @@ RCT_EXPORT_METHOD(screen:(NSString*)screenName properties:(NSDictionary *)proper
     [[SEGAnalytics sharedAnalytics] screen:screenName properties:[self toStringDictionary:properties]];
 }
 
+RCT_EXPORT_METHOD(alias:(NSString*)newId) {
+    [[SEGAnalytics sharedAnalytics] alias:newId];
+}
+
 -(NSMutableDictionary*) toStringDictionary: (NSDictionary *)properties {
     NSMutableDictionary *stringDictionary = [[NSMutableDictionary alloc] init];
     for (NSString* key in [properties allKeys]) {


### PR DESCRIPTION
Using Mixpanel with Segment requires the [`alias` method to be called](https://segment.com/docs/spec/alias/) just once at exactly the right time for Mixpanel to associate an anonymous track with a named track when the user signs up.

This PR adds the alias wrapper to both Andorid and iOS.

(This is a reboot of PR #8, cleaner with only one commit)