### PR TITLE
fix(iOS): add support for dynamic frameworks

### DIFF
--- a/ios/SegmentAnalytics/Classes/SegmentAnalytics.m
+++ b/ios/SegmentAnalytics/Classes/SegmentAnalytics.m
@@ -4,7 +4,12 @@
 
 #import "SegmentAnalytics.h"
 #import "RCTConvert.h"
+#if __has_include(<Analytics/SEGAnalytics.h>)
 #import <Analytics/SEGAnalytics.h>
+#else
+#import "SEGAnalytics.h"
+#endif
+
 #import <Foundation/Foundation.h>
 
 @implementation SegmentAnalytics


### PR DESCRIPTION
If one uses CocoaPods and installs the 'Analytics' pod using the option for dyamic frameworks (use_frameworks!) The import of SEGAnalytics will no longer work. With this support we support dynamic frameworks, while being backwards compatible.