### PR TITLE
Updates to work on Android 0.47

### DIFF
--- a/android/src/main/java/com/charlires/segmentanalytics/SegmentAnalyticsModule.java
+++ b/android/src/main/java/com/charlires/segmentanalytics/SegmentAnalyticsModule.java
@@ -91,6 +91,7 @@ public class SegmentAnalyticsModule extends ReactContextBaseJavaModule {
         } catch (Exception e) {
             Log.e("SegmentAnalyticsModule", "Failed to alias " + newId + ". " + e.getMessage());
         }
+    }
 
     private boolean nullOrEmpty(@Nullable ReadableMap readableMap) {
         return readableMap == null || !readableMap.keySetIterator().hasNextKey();

--- a/android/src/main/java/com/charlires/segmentanalytics/SegmentAnalyticsPackage.java
+++ b/android/src/main/java/com/charlires/segmentanalytics/SegmentAnalyticsPackage.java
@@ -25,7 +25,6 @@ public class SegmentAnalyticsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new SegmentAnalyticsModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/ios/SegmentAnalytics.xcodeproj/project.pbxproj
+++ b/ios/SegmentAnalytics.xcodeproj/project.pbxproj
@@ -219,6 +219,11 @@
 		094964CB1E156E4D0097C117 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "$(SRCROOT)/../../react-native/React/**",
+                    "$(SRCROOT)/../../../ios/**",
+                );
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -228,6 +233,11 @@
 		094964CC1E156E4D0097C117 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+                    "$(inherited)",
+                    "$(SRCROOT)/../../react-native/React/**",
+                    "$(SRCROOT)/../../../ios/**",
+                );
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
- Brings up to date with upstream
- Makes a fix on Android to be compatible with 0.47+

**NOTE:** This should only be merged once the main app upgrade branch is the primary app. Otherwise it could break existing versions when developing/deploying with lower than 0.47.